### PR TITLE
java项目添加NumHelper类，修正敏感词库的存取方法

### DIFF
--- a/java/toolgood.words/src/main/java/toolgood/words/NumHelper.java
+++ b/java/toolgood.words/src/main/java/toolgood/words/NumHelper.java
@@ -1,0 +1,188 @@
+package toolgood.words;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * @author yongxuan.he
+ * @date 2020/3/17
+ */
+public class NumHelper {
+
+    public enum SerializableType {
+        /** 大小在-128~127之间的整数，占用空间为1字节 */
+        TINY_INT(1),
+        /** 大小在-32768~32767之间的整数，占用空间为2字节 */
+        SMALL_INT(2),
+        /** 大小在-8388608~8388607之间的整数，占用空间为3字节 */
+        MEDIUM_INT(3),
+        /** int类型 */
+        INT(4),
+        ;
+
+        private final int flag;
+
+        private static Map<Integer, SerializableType> typeMap;
+        static {
+            Map<Integer, SerializableType> tmpMap = new HashMap<>();
+            for (SerializableType type : SerializableType.values()) {
+                tmpMap.put(type.getFlag(), type);
+            }
+            typeMap = tmpMap;
+        }
+        public static SerializableType getType(int flag) {
+            return typeMap.get(flag);
+        }
+
+        SerializableType(int flag) {
+            this.flag = flag;
+        }
+
+        public int getFlag() {
+            return flag;
+        }
+    }
+
+    private interface Serializer {
+        byte[] serialize(int a);
+    }
+
+    private static Serializer tinyIntWriter = v -> {
+        if (v < -128 || v > 127) {
+            throw new RuntimeException("not tinyInt: " + v);
+        }
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        out.write(v);
+        return out.toByteArray();
+    };
+    private static Serializer smallIntWriter = v -> {
+        if (v < -32768 || v > 32767) {
+            throw new RuntimeException("not smallInt: " + v);
+        }
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        out.write((v >>> 8) & 0xFF);
+        out.write(v & 0xFF);
+        return out.toByteArray();
+    };
+    private static Serializer mediumIntWriter = v -> {
+        if (v < -8388608 || v > 8388607) {
+            throw new RuntimeException("not mediumInt: " + v);
+        }
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        out.write((v >>> 16) & 0xFF);
+        out.write((v >>> 8) & 0xFF);
+        out.write(v & 0xFF);
+        return out.toByteArray();
+    };
+
+    private static Serializer intWriter = v -> {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        out.write((v >>> 24) & 0xFF);
+        out.write((v >>> 16) & 0xFF);
+        out.write((v >>> 8) & 0xFF);
+        out.write(v & 0xFF);
+        return out.toByteArray();
+    };
+
+    private static final Map<SerializableType, Serializer> simpleWriterMap = new ConcurrentHashMap<>();
+    static {
+        simpleWriterMap.put(SerializableType.TINY_INT, tinyIntWriter);
+        simpleWriterMap.put(SerializableType.SMALL_INT, smallIntWriter);
+        simpleWriterMap.put(SerializableType.MEDIUM_INT, mediumIntWriter);
+        simpleWriterMap.put(SerializableType.INT, intWriter);
+    }
+
+    public static byte[] serialize(int v) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        Serializer serializer;
+        int typeFlag;
+
+        if(v >= -128 && v<= 127) {
+            serializer = simpleWriterMap.get(SerializableType.TINY_INT);
+            typeFlag = SerializableType.TINY_INT.getFlag();
+        } else if(v >= -32768 && v <= 32767) {
+            serializer = simpleWriterMap.get(SerializableType.SMALL_INT);
+            typeFlag = SerializableType.SMALL_INT.getFlag();
+        } else if(v >= -8388608 && v <= 8388607){
+            serializer = simpleWriterMap.get(SerializableType.MEDIUM_INT);
+            typeFlag = SerializableType.MEDIUM_INT.getFlag();
+        } else {
+            serializer = simpleWriterMap.get(SerializableType.INT);
+            typeFlag = SerializableType.INT.getFlag();
+        }
+        out.write(typeFlag);
+        byte[] bytes = serializer.serialize(v);
+        out.write(bytes, 0, bytes.length);
+        return out.toByteArray();
+    }
+
+    public interface Deserializer {
+        int deserialize(InputStream in) throws IOException;
+    }
+
+    private static Deserializer tinyIntReader = in -> {
+        int ch = in.read();
+        if (ch < 0)
+            throw new RuntimeException("deserializing");
+        if ((0x80 & ch) == 0x80) {
+            ch = 0xffffff00 | ch;
+        }
+        return ch;
+    };
+    private static Deserializer smallIntReader = in -> {
+        int ch1 = in.read();
+        int ch2 = in.read();
+        if ((ch1 | ch2) < 0)
+            throw new RuntimeException("deserializing");
+        int ch = (ch1 << 8) + ch2;
+        if ((0x8000 & ch) == 0x8000) {
+            ch = 0xffff0000 | ch;
+        }
+        return ch;
+    };
+    private static Deserializer mediumIntReader = in -> {
+        int ch1 = in.read();
+        int ch2 = in.read();
+        int ch3 = in.read();
+        if ((ch1 | ch2 | ch3) < 0)
+            throw new RuntimeException("deserializing");
+        int ch = (ch1 << 16) + (ch2 << 8) + (ch3);
+        if ((0x800000 & ch) == 0x800000) {
+            ch = 0xff000000 | ch;
+        }
+        return ch;
+    };
+
+    private static Deserializer intReader = in -> {
+        int ch1 = in.read();
+        int ch2 = in.read();
+        int ch3 = in.read();
+        int ch4 = in.read();
+        if ((ch1 | ch2 | ch3 | ch4) < 0)
+            throw new RuntimeException("deserializing");
+        return ((ch1 << 24) + (ch2 << 16) + (ch3 << 8) + ch4);
+    };
+
+    private static final Map<SerializableType, Deserializer> simpleReaderMap = new ConcurrentHashMap<>();
+    static {
+        simpleReaderMap.put(SerializableType.TINY_INT, tinyIntReader);
+        simpleReaderMap.put(SerializableType.SMALL_INT, smallIntReader);
+        simpleReaderMap.put(SerializableType.MEDIUM_INT, mediumIntReader);
+        simpleReaderMap.put(SerializableType.INT, intReader);
+    }
+
+    public static int read(InputStream in) throws IOException {
+        int flag = in.read();
+        SerializableType type = SerializableType.getType(flag);
+        Deserializer deserializer = simpleReaderMap.get(type);
+
+        if(deserializer == null) {
+            throw new RuntimeException("wrong flag: " + flag);
+        }
+        return deserializer.deserialize(in);
+    }
+}

--- a/java/toolgood.words/src/main/java/toolgood/words/internals/BaseSearchEx.java
+++ b/java/toolgood.words/src/main/java/toolgood/words/internals/BaseSearchEx.java
@@ -1,12 +1,10 @@
 package toolgood.words.internals;
 
+import toolgood.words.NumHelper;
+
 import static java.util.stream.Collectors.toMap;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
+import java.io.*;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Hashtable;
@@ -14,7 +12,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-public abstract class BaseSearchEx{
+public abstract class BaseSearchEx {
     protected String[] _keywords;
     protected int[][] _guides;
     protected int[] _key;
@@ -24,114 +22,119 @@ public abstract class BaseSearchEx{
 
     /**
      * 保存
+     *
      * @param filePath 文件地址
      * @throws IOException
      */
-    public void Save(String filePath) throws IOException
-    {
+    public void Save(String filePath) throws IOException {
         File fi = new File(filePath);
         FileOutputStream fs = new FileOutputStream(fi);
         Save(fs);
         fs.close();
     }
 
-    protected void Save(FileOutputStream bw) throws IOException
-    {
-        bw.write(_keywords.length);
+    protected void Save(FileOutputStream bw) throws IOException {
+        bw.write(NumHelper.serialize(_keywords.length));
         for (String item : _keywords) {
-            byte[] bytes=item.getBytes();
-            bw.write(bytes.length);  
+            byte[] bytes = item.getBytes();
+            bw.write(NumHelper.serialize(bytes.length));
             bw.write(bytes);
         }
 
-        bw.write(_guides.length);
+        bw.write(NumHelper.serialize(_guides.length));
         for (int[] guide : _guides) {
-            bw.write(guide.length);
+            bw.write(NumHelper.serialize(guide.length));
             for (int item : guide) {
-                bw.write(item);
+                bw.write(NumHelper.serialize(item));
             }
         }
 
-        bw.write(_key.length);
-        for (int item : _key) { bw.write(item); }
-   
-        bw.write(_next.length);
-        for (int item : _next) { bw.write(item); }
- 
-        bw.write(_check.length);
-        for (int item : _check) { bw.write(item); }
+        bw.write(NumHelper.serialize(_key.length));
+        for (int item : _key) {
+            bw.write(NumHelper.serialize(item));
+        }
 
-         bw.write(_dict.length);
-        for (int item : _dict) { bw.write(item); }
+        bw.write(NumHelper.serialize(_next.length));
+        for (int item : _next) {
+            bw.write(NumHelper.serialize(item));
+        }
+
+        bw.write(NumHelper.serialize(_check.length));
+        for (int item : _check) {
+            bw.write(NumHelper.serialize(item));
+        }
+
+        bw.write(NumHelper.serialize(_dict.length));
+        for (int item : _dict) {
+            bw.write(NumHelper.serialize(item));
+        }
     }
- 
+
     /**
      * 加载
+     *
      * @param filePath
      * @throws FileNotFoundException
      * @throws IOException
      */
-    public void Load(String filePath) throws FileNotFoundException,IOException
-    {
+    public void Load(String filePath) throws FileNotFoundException, IOException {
         File fi = new File(filePath);
-        FileInputStream fs = new FileInputStream(fi);
-        Load(fs);
-        fs.close();
+        InputStream in = new BufferedInputStream(new FileInputStream(fi));
+        Load(in);
+        in.close();
     }
 
-    protected void Load(FileInputStream br) throws IOException
-    {
-        int length =br.read();
-        _keywords=new String[length];
+    public void Load(InputStream br) throws IOException {
+        int length = NumHelper.read(br);
+        _keywords = new String[length];
         for (int i = 0; i < length; i++) {
-            int l=br.read();
-            byte[] bytes=new byte[l];
-            br.read(bytes,0,l);
-            _keywords[i]=new String(bytes);
+            int l = NumHelper.read(br);
+            byte[] bytes = new byte[l];
+            br.read(bytes, 0, l);
+            _keywords[i] = new String(bytes);
         }
-        length =br.read();
-        _guides=new int[length][];
+        length = NumHelper.read(br);
+        _guides = new int[length][];
         for (int i = 0; i < length; i++) {
-            int length2 = br.read();
-            _guides[i]=new int[length2];
+            int length2 = NumHelper.read(br);
+            _guides[i] = new int[length2];
             for (int j = 0; j < length2; j++) {
-                _guides[i][j]=br.read();
+                _guides[i][j] = NumHelper.read(br);
             }
         }
 
-        length =br.read();
-        _key=new int[length];
+        length = NumHelper.read(br);
+        _key = new int[length];
         for (int i = 0; i < length; i++) {
-            _key[i]=br.read();
-        }
- 
-        length =br.read();
-        _next=new int[length];
-        for (int i = 0; i < length; i++) {
-            _next[i]=br.read();
+            _key[i] = NumHelper.read(br);
         }
 
-        length =br.read();
-        _check=new int[length];
+        length = NumHelper.read(br);
+        _next = new int[length];
         for (int i = 0; i < length; i++) {
-            _check[i]=br.read();
+            _next[i] = NumHelper.read(br);
         }
 
-        length =br.read();
-        _dict=new int[length];
+        length = NumHelper.read(br);
+        _check = new int[length];
         for (int i = 0; i < length; i++) {
-            _dict[i]=br.read();
+            _check[i] = NumHelper.read(br);
+        }
+
+        length = NumHelper.read(br);
+        _dict = new int[length];
+        for (int i = 0; i < length; i++) {
+            _dict[i] = NumHelper.read(br);
         }
     }
- 
 
 
     /**
      * 设置关键字
+     *
      * @param keywords
      */
-    public void SetKeywords(List<String> keywords)
-    {
+    public void SetKeywords(List<String> keywords) {
         _keywords = keywords.toArray(new String[0]);
         int length = CreateDict(keywords);
         TrieNodeEx root = new TrieNodeEx();
@@ -140,36 +143,38 @@ public abstract class BaseSearchEx{
             String p = _keywords[i];
             TrieNodeEx nd = root;
             for (int j = 0; j < p.length(); j++) {
-                nd = nd.Add((char)_dict[p.charAt(j)]);
+                nd = nd.Add((char) _dict[p.charAt(j)]);
             }
             nd.SetResults(i);
         }
 
         List<TrieNodeEx> nodes = new ArrayList<TrieNodeEx>();
         for (int key : root.m_values.keySet()) {
-            TrieNodeEx nd=root.m_values.get(key);
+            TrieNodeEx nd = root.m_values.get(key);
             nd.Failure = root;
             for (TrieNodeEx trans : nd.m_values.values()) {
                 nodes.add(trans);
             }
         }
-        while(nodes.size()!=0){
+        while (nodes.size() != 0) {
             List<TrieNodeEx> newNodes = new ArrayList<TrieNodeEx>();
             for (TrieNodeEx nd : nodes) {
                 TrieNodeEx r = nd.Parent.Failure;
-                int c =  (int)nd.Char;
-                while (r != null && !r.m_values.containsKey( c)){r = r.Failure;} 
-                if (r == null){
+                int c = (int) nd.Char;
+                while (r != null && !r.m_values.containsKey(c)) {
+                    r = r.Failure;
+                }
+                if (r == null) {
                     nd.Failure = root;
-                }else {
+                } else {
                     nd.Failure = r.m_values.get(c);
                     for (Integer result : nd.Failure.Results) {
                         nd.SetResults(result);
                     }
                 }
-                
+
                 for (TrieNodeEx child : nd.m_values.values()) {
-                     newNodes.add(child);
+                    newNodes.add(child);
                 }
             }
             nodes = newNodes;
@@ -181,23 +186,21 @@ public abstract class BaseSearchEx{
         build(root, length);
     }
 
-    private void TryLinks(TrieNodeEx node)
-    {
+    private void TryLinks(TrieNodeEx node) {
         node.Merge(node.Failure);
         for (TrieNodeEx item : node.m_values.values()) {
             TryLinks(item);
         }
     }
 
-    private void build(TrieNodeEx root, int length)
-    {
+    private void build(TrieNodeEx root, int length) {
         TrieNodeEx[] has = new TrieNodeEx[0x00FFFFFF];
         length = root.Rank(has) + length + 1;
         _key = new int[length];
         _next = new int[length];
         _check = new int[length];
         List<Integer[]> guides = new ArrayList<Integer[]>();
-        guides.add(new Integer[] { 0 });
+        guides.add(new Integer[]{0});
         for (int i = 0; i < length; i++) {
             TrieNodeEx item = has[i];
             if (item == null) continue;
@@ -205,23 +208,22 @@ public abstract class BaseSearchEx{
             _next[i] = item.Next;
             if (item.End) {
                 _check[i] = guides.size();
-                Integer[] result= item.Results.toArray(new Integer[0]);
+                Integer[] result = item.Results.toArray(new Integer[0]);
                 guides.add(result);
             }
         }
-        _guides=new int[guides.size()][];
+        _guides = new int[guides.size()][];
         for (int i = 0; i < guides.size(); i++) {
-            Integer[] array= guides.get(i);
-            _guides[i]=new int[array.length];
+            Integer[] array = guides.get(i);
+            _guides[i] = new int[array.length];
             for (int j = 0; j < array.length; j++) {
-                _guides[i][j]=array[j];
+                _guides[i][j] = array[j];
             }
         }
     }
 
-    
-    private int CreateDict(List<String> keywords)
-    {
+
+    private int CreateDict(List<String> keywords) {
         Map<Character, Integer> dictionary = new Hashtable<Character, Integer>();
 
         for (String keyword : keywords) {
@@ -229,20 +231,20 @@ public abstract class BaseSearchEx{
                 Character item = keyword.charAt(i);
                 if (dictionary.containsKey(item)) {
                     if (i > 0)
-                    dictionary.put(item, dictionary.get(item)+2);
+                        dictionary.put(item, dictionary.get(item) + 2);
                 } else {
                     dictionary.put(item, i > 0 ? 2 : 1);
                 }
             }
         }
         Map<Character, Integer> dictionary2 = dictionary
-            .entrySet()
-            .stream()
-            .sorted(Collections.reverseOrder(Map.Entry.comparingByValue()))
-            .collect(
-                toMap(Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e2,
-                    LinkedHashMap::new));
- 
+                .entrySet()
+                .stream()
+                .sorted(Collections.reverseOrder(Map.Entry.comparingByValue()))
+                .collect(
+                        toMap(Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e2,
+                                LinkedHashMap::new));
+
 
         List<Character> list2 = new ArrayList<Character>();
         boolean sh = false;

--- a/java/toolgood.words/src/test/java/toolgood/words/DemoApplication.java
+++ b/java/toolgood.words/src/test/java/toolgood/words/DemoApplication.java
@@ -1,6 +1,8 @@
 package toolgood.words;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -8,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.util.StopWatch;
 
 import toolgood.words.IllegalWordsSearch;
@@ -29,9 +32,10 @@ public class DemoApplication {
 		test_IllegalWordsSearch();
 
 		try {
-			test_save_load();
+//			test_save_load();
+            test_IllegalWordsSearch_loadWordsFormBinaryFile();
 		} catch (Exception e) {
-			//TODO: handle exception
+			e.printStackTrace();
 		}
 		test_times();
 	}
@@ -317,5 +321,52 @@ public class DemoApplication {
 			e.printStackTrace();
 		}
 		return contentBuilder.toString();
+	}
+
+	private static void test_IllegalWordsSearch_loadWordsFormBinaryFile() throws IOException {
+
+
+		long l1 = System.currentTimeMillis();
+
+		IllegalWordsSearch search = new IllegalWordsSearch();
+		long l2 = System.currentTimeMillis();
+		System.out.println("IllegalWordsSearch init time:" + (l2 - l1));
+
+		search.Load(new ClassPathResource("IllegalWordsSearch.dat").getFile().getAbsolutePath());
+		long l3 = System.currentTimeMillis();
+		System.out.println("load Load time:" + (l3 - l2));
+
+		String test = "卖毒品哈哈哈哈毛澤東porn哈哈哈哈胡锦涛pornasds哈哈哈哈胡锦涛porn哈哈哈哈胡锦涛porn哈哈哈哈胡锦涛胡锦涛撒旦撒旦ｐｏｒｎporn哈哈哈哈胡锦涛porn哈哈哈哈胡锦涛porn" +
+				"哈哈哈哈胡锦涛porn哈哈哈哈胡锦涛porn哈哈哈哈胡錦濤porn哈哈哈哈胡锦涛porn哈哈哈哈胡锦涛porn哈哈哈哈胡锦涛porn哈哈哈哈胡锦涛porn哈哈哈哈胡锦涛porn" +
+				"哈哈哈哈胡锦涛porn哈哈哈哈胡锦涛porn哈哈哈哈或porn哈哈哈哈或porn哈哈哈哈或porn哈哈哈哈或porn哈哈哈哈或porn哈哈哈哈或porn哈哈哈哈或porn哈哈哈哈或porn哈哈哈哈或porn" +
+				"哈哈哈哈或porn哈哈哈哈或porn哈哈哈哈或porn哈哈哈哈或porn哈哈哈哈或porn哈哈哈哈或porn哈哈哈哈或porn哈哈哈哈或porn哈哈哈哈或porn哈哈哈哈或porn哈哈哈哈或porn" +
+				"哈哈哈哈或porn哈哈哈哈或porn哈哈哈哈或porn哈哈哈哈或porn哈哈哈哈或porn哈哈哈哈或porn哈哈哈哈或porn哈哈哈哈或porn哈哈哈哈或porn哈哈哈哈或porn哈哈哈哈或porn" +
+				"哈哈哈哈或porn哈哈哈哈或porn哈哈哈哈或porn哈哈哈哈或porn哈哈哈哈或porn哈哈哈哈或porn哈哈哈哈或porn哈哈哈哈或porn哈哈哈哈或porn哈哈哈哈或porn哈哈哈哈或porn" +
+				"哈哈哈哈或porn哈哈哈哈或porn哈哈哈哈或porn哈哈哈哈或porn哈哈哈哈或porn哈哈哈哈或porn哈哈哈哈或porn哈哈哈哈或porn哈哈哈哈或porn哈哈哈哈或porn";
+
+		boolean b = search.ContainsAny(test);
+		if (!b) {
+			System.out.println("ContainsAny is Error.");
+		}
+		long l4 = System.currentTimeMillis();
+		System.out.println("ContainsAny time:" + (l4 - l3));
+
+		String str = search.Replace(test, '*');
+		long l5 = System.currentTimeMillis();
+		System.out.println("Replace Result:" + str);
+		System.out.println("Replace time:" + (l5 - l4));
+	}
+
+	private static void test_IllegalWordsSearch_saveToBinaryFile() throws IOException {
+		List<String> list = new ArrayList<>();
+		try (BufferedReader bufferedReader = new BufferedReader(
+				new InputStreamReader(new ClassPathResource("sensi_words.txt").getInputStream()))) {
+			for (String line = bufferedReader.readLine(); line != null; line = bufferedReader.readLine()) {
+				list.add(line);
+			}
+		}
+		IllegalWordsSearch search = new IllegalWordsSearch();
+		search.SetKeywords(list);
+		search.Save("IllegalWordsSearch.dat");
 	}
 }


### PR DESCRIPTION
原来的java项目中存取数字只用了一个字节，而实际使用中超过128的数字，一个字节无法存储的，所以导致存取中都会出现空指针异常。
NumHelper类对整型数字进行了分类：TINY_INT，大小在-128 ~ 127之间的整数，占用空间为1字节；SMALL_INT，大小在-32768 ~ 32767之间的整数，占用空间为2字节；MEDIUM_INT，大小在-8388608 ~ 8388607之间的整数，占用空间为3字节；超过以上范围的为 INT, 占用空间为4字节。取1个字节作为标志位，修改之后的整型数字占用 2 - 5 个字节，能准确地存储数字。
此外，原来的字库的读取方法使用了FileInputStream，而使用BufferedInputStream将其进行包装，可以将加载速度提升百倍以上。