### PR TITLE
修改字符bug

### DIFF
--- a/golang/ToolGood/Words/StringSearch.go
+++ b/golang/ToolGood/Words/StringSearch.go
@@ -26,7 +26,8 @@ func (this *StringSearch) SetKeywords(keywords []string) {
 		if length > 0 {
 			var nd *TrieNode
 			nd = root
-			for i, ch := range p {
+			i:=0
+			for _, ch := range p {
 				nd = nd.Add(int(ch))
 				if nd.Layer == 0 {
 					nd.Layer = i + 1
@@ -38,6 +39,7 @@ func (this *StringSearch) SetKeywords(keywords []string) {
 						trieNodes.Items = append(trieNodes.Items, nd)
 					}
 				}
+				i++
 			}
 			nd.SetResults(r)
 		}

--- a/golang/ToolGood/Words/WordsSearch.go
+++ b/golang/ToolGood/Words/WordsSearch.go
@@ -24,7 +24,8 @@ func (this *WordsSearch) SetKeywords(keywords []string) {
 		if length > 0 {
 			var nd *TrieNode
 			nd = root
-			for i, ch := range p {
+			i:=0
+			for _, ch := range p {
 				nd = nd.Add(int(ch))
 				if nd.Layer == 0 {
 					nd.Layer = i + 1
@@ -36,6 +37,7 @@ func (this *WordsSearch) SetKeywords(keywords []string) {
 						trieNodes.Items = append(trieNodes.Items, nd)
 					}
 				}
+				i++
 			}
 			nd.SetResults(r)
 		}


### PR DESCRIPTION

修复 golang添加utf8字符串为模式串，可能出现ac自动机创建失败问题
![image](https://github.com/user-attachments/assets/9d9e4d1c-94cd-4dd5-91cd-9d582905c3a6)
![屏幕截图 2024-08-27 211215](https://github.com/user-attachments/assets/c2b3c18f-f0a8-4bb0-9022-f68528e80a2b)
go中range 遍历字符串时是按 Unicode 编码点来遍历的。每个字符可能占用多个字节，原代码写法会出现层数中间的空缺（如只存”f\u00a0a\u00a0l\u00a0u\u00a0n”为模式串时,allNodeLayers[2]==nil）
![屏幕截图 2024-08-27 212558](https://github.com/user-attachments/assets/ac0a86b7-c1ed-448c-b2f9-c2237f639afd)
导致在创建AC自动机时，以层数顺序遍历`allNodeLayers`时出现nil的情况，发生 painc
![屏幕截图 2024-08-27 212627](https://github.com/user-attachments/assets/23494bee-aa06-4e74-9da1-5f2d56d3df04)

