### PR TITLE
修复排序bug

### DIFF
--- a/golang/ToolGood/Words/internals/BaseSearchEx.go
+++ b/golang/ToolGood/Words/internals/BaseSearchEx.go
@@ -282,20 +282,28 @@ func (this *BaseSearchEx)CreateDict(keywords []string) int {
 	}
 	return len(dictionary)  
 }
-func (s *BaseSearchEx)sortMap(mp map[int32]int) []int32 {
-	var newMp = make([]int, 0)
-	var newMpKey = make([]int32, 0)
-	for oldk, v := range mp {
-	   newMp = append(newMp, v)
-	   newMpKey = append(newMpKey, oldk)
-	}
-	sort.Ints(newMp)
+func (s *BaseSearchEx) sortMap(mp map[int32]int) []int32 {
+    
+    type kv struct {
+        Key   int32
+        Value int
+    }
+    var sortedPairs []kv
+    for k, v := range mp {
+        sortedPairs = append(sortedPairs, kv{k, v})
+    }
 
-	list:=make([]int32, 0)
-	for k, _ := range newMp {
-		list = append(list, newMpKey[k])
-	}
-	return list
+    
+    sort.Slice(sortedPairs, func(i, j int) bool {
+        return sortedPairs[i].Value < sortedPairs[j].Value
+    })
+
+   
+    var sortedKeys []int32
+    for _, pair := range sortedPairs {
+        sortedKeys = append(sortedKeys, pair.Key)
+    }
+
+    return sortedKeys
 }
- 
  


### PR DESCRIPTION
修复golang排序bug #101 
单侧：

- 原代码
![2410f58c805ad989a4eae5f2b055000](https://github.com/user-attachments/assets/1c73402d-7b92-4065-a6bd-43a03d056b24)

- 修改后
![6814ae9849d81b62673ffd9ff7227cf](https://github.com/user-attachments/assets/6454ef47-91b2-4474-b0bc-d3123c384c5e)
